### PR TITLE
Fix code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import DOMPurify from "dompurify";
 
 //  Set the pop-up window content
 export const setPopup = ({
@@ -15,7 +16,7 @@ export const setPopup = ({
   }
   document.querySelector(".pop-up-wrapper").style.display = "block";
   document.querySelector(".pop-up-header").textContent = heading;
-  document.querySelector(".pop-up-text").innerHTML = text;
+  document.querySelector(".pop-up-text").innerHTML = DOMPurify.sanitize(text);
 
   if (options) {
     document.querySelector(".pop-up-wrapper .option").style.display = "flex";


### PR DESCRIPTION
Fixes [https://github.com/younes-atyq/guacachat/security/code-scanning/1](https://github.com/younes-atyq/guacachat/security/code-scanning/1)

To fix the problem, we need to ensure that any text assigned to `innerHTML` is properly sanitized to prevent XSS attacks. The best way to do this is to use a library like `DOMPurify` to sanitize the `text` before assigning it to `innerHTML`.

1. Install the `dompurify` library.
2. Import `DOMPurify` in `src/components/Popup.jsx`.
3. Use `DOMPurify.sanitize` to sanitize the `text` before assigning it to `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
